### PR TITLE
Removed listserv task and redundant columns

### DIFF
--- a/Checklists/team-based-checklists/product-new-hire-checklist.md
+++ b/Checklists/team-based-checklists/product-new-hire-checklist.md
@@ -5,95 +5,68 @@ Product New Employee Checklist
 <table>
   <thead> 
     <tr> 
-      <th scope="col"></th> 
+      <th scope="col">Task</th> 
       <th scope="col">&#10003;</th>
       <th scope="col">Task</th>
       <th scope="col">When</th>
-      <th scope="col">Who Has Information / Completes Task</th>
-      <th scope="col">Who Receives Information </th>
       <th scope="col">Where the information lives / notes</th>
     </tr>
   </thead>
     <tr>
-    <td scope="row">8</td> 
+    <td scope="row">1</td> 
     <td>&#9744;</td>
     <td>Join the Slack channels #product and #project-intake.</td>
     <td>Day 1</td>
-    <td></td>
-    <td> New Hire</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td scope="row">1</td> 
-    <td>&#9744;</td>
-    <td>Make sure you're added to the Product team listserv and team calendar</td>
-    <td>Day 2</td>
-    <td>Buddy and/or Director</td>
-    <td>New Hire</td>
-    <td></td>
+    <td>Get access to <a href="https://handbook.18f.gov/slack/">slack.</a></td>
   </tr>
   <tr>
     <td scope="row">2</td> 
     <td>&#9744;</td>
     <td>Read Product Lead Guide</td>
     <td>First Week</td>
-    <td></td>
-    <td> New Hire</td>
-    <td><a href="https://docs.google.com/document/d/1Jr_Bizbp4UjbINqglP86bElSWWI4XWrt7fVbFqlqNEM/edit#heading=h.j9qo16r47si9">Product Lead Guide</a>  Don’t worry if this doesn’t make sense yet. Bookmark it and plan to look at it again.</td>
+    <td>This is the new <a href="https://github.com/18F/product-guide">Product Lead Guide.</a>  Don’t worry if this doesn’t make sense yet. Bookmark it and plan to look at it again.  An older version (soon to be deprecated) is located <a href="https://docs.google.com/document/d/1Jr_Bizbp4UjbINqglP86bElSWWI4XWrt7fVbFqlqNEM/edit#heading=h.j9qo16r47si9">here</a>.  </td>
    </tr>
-  <tr>
-    <td scope="row">5</td> 
-    <td>&#9744;</td>
-    <td>Set up a virtual coffee with Josh. </td>
-    <td>First week</td>
-    <td></td>
-    <td> New Hire</td>
-    <td>You won’t know what to talk about, but that’s okay. It’s reassuring to know you’re not expected to know what’s going on yet.</td>
-    </tr>
-  <tr>
-    <td scope="row">6</td> 
-    <td>&#9744;</td>
-    <td>Have virtual coffees (or real ones!) with other PMs. Ask tons of questions. Listen a lot.</td>
-    <td>First week</td>
-    <td></td>
-    <td> New Hire</td>
-    <td>Don’t be worried about reaching out. Everyone was a new hire. </td>
-  </tr>
   <tr>
     <td scope="row">3</td> 
     <td>&#9744;</td>
+    <td>Set up a virtual coffee with Josh. </td>
+    <td>First week</td>
+    <td>You won’t know what to talk about, but that’s okay. It’s reassuring to know you’re not expected to know what’s going on yet.</td>
+    </tr>
+  <tr>
+    <td scope="row">4</td> 
+    <td>&#9744;</td>
+    <td>Have virtual coffees (or real ones!) with other PMs. Ask tons of questions. Listen a lot.</td>
+    <td>First week</td>
+    <td>Don’t be worried about reaching out. Everyone was a new hire. </td>
+  </tr>
+  <tr>
+    <td scope="row">5</td> 
+    <td>&#9744;</td>
     <td>Read Product Manager Trello board</td>
     <td>First two weeks</td>
-    <td></td>
-    <td> New Hire</td>
     <td>The Trello board is here <a href="https://trello.com/b/9HJTqrjP/18f-pm-guide">here</a> Don’t worry. This won’t make a lot of sense yet either. Bookmark it and plan to keep an eye on it. </td>
   </tr>
     <tr>
-    <td scope="row">9</td> 
+    <td scope="row">6</td> 
     <td>&#9744;</td>
     <td>Set up a second coffee with Josh. (You’ll be ready to start thinking about looking for a product now.)</td>
     <td>Week 3</td>
     <td></td>
-    <td> New Hire</td>
-    <td></td>
   </tr>
   <tr>
-    <td scope="row">4</td> 
+    <td scope="row">7</td> 
     <td>&#9744;</td>
     <td>If you don’t already know how to use GitHub, Murally, Trello, and Slack, learn.</td>
     <td>First month</td>
-    <td></td>
-    <td> New Hire</td>
     <td>Knowing these -- if you don’t already -- will help you feel less lost. We have guides for them located in 
       <a href= "https://handbook.18f.gov">our handbook</a></td>
   </tr>
     <tr>
-    <td scope="row">7</td> 
+    <td scope="row">8</td> 
     <td>&#9744;</td>
     <td>Have virtual coffees (or real ones!) with other PMs. Ask tons of questions. Listen a lot.</td>
     <td>First month</td>
-    <td></td>
-    <td> New Hire</td>
     <td>Don’t be worried about reaching out. Everyone was a new hire. </td>
   </tr>
 </table>


### PR DESCRIPTION
Making updates to the product new hire checklist
* Removed task regarding getting added to the team listserv and calendar (per feedback from #product).  This resulted in 2 columns being obsolete
* Added new product guide link
* Corrected Task numbers